### PR TITLE
Follow setup-cli v1 and latest cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,9 @@ runs:
         persist-credentials: true
         fetch-depth: 0
     - name: Set up supabase cli
-      uses: supabase/setup-cli@v1.0.2
+      uses: supabase/setup-cli@v1
       with:
-        version: 1.5.3
+        version: latest
     - name: "Generate database typescript types"
       shell: bash
       env:


### PR DESCRIPTION
Supabase project follows a fast development schedule and versions becomes outdated quite fast.
This solution addresses this for less maintenance of the GH action with the compromise of possible errors in new setup-cli or cli new versions